### PR TITLE
Grant netmgrd proper unix perms

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -441,6 +441,8 @@ service qmuxd /system/bin/qmuxd
 
 service netmgrd /system/bin/netmgrd
     class main
+    user root
+    group root wifi wakelock radio inet
 
 # Adjust socket buffer to enlarge TCP receive window for high bandwidth
 # but only if ro.data.large_tcp_window_size property is set.


### PR DESCRIPTION
Do not grant DAC override permission which would allow this daemon
unix permissions to everything.

avc: denied { dac_override } for capability=1 scontext=u:r:netmgrd:s0 tcontext=u:r:netmgrd:s0 tclass=capability

Adding
wifi group to access
/data/misc/net/rt_tables
-rw-r--r--  1 system wifi   130 2016-05-11 09:58 rt_tables

wakelock group to access:
/sys/power/wake_lock
-rw-rw----  1 radio  wakelock 4096 1970-01-19 15:03 wake_lock

radio/inet groups to access
/dev/socket/netmgr/netmgr_connect_socket
srw-rw---- 1 radio inet    0 1970-01-19 15:03 netmgr_connect_socket

Change-Id: I7ed6a98dd85bf7efa8cab0b8a0851217f030ba8b